### PR TITLE
Increase "Tested up to:"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: ash_hitch
 Tags: SEO, Yoast, WPGraphQL, GraphQL, Headless WordPress, Decoupled WordPress, JAMStack
 Requires at least: 5.0
-Tested up to: 6
+Tested up to: 6.1.1
 Requires PHP: 7.1
 Stable tag: 4.20.0
 License: GPLv3


### PR DESCRIPTION
Currently there's a notice in the WordPress plugin repo because the "Tested up to:" version hasn't been bumped lately:

<img width="1552" alt="WPGraphQL_Yoast_SEO_Addon__WordPress_plugin__WordPress org_2022-11-30_10-31-29" src="https://user-images.githubusercontent.com/1377956/204678579-25abd0b8-4fab-4e29-adf3-ec3d92dbe759.png">

I've been using this successfully with 6.1.1. @ashhitch I wasn't sure if you would do a release for this change. If so I can bump the plugin version numbers for you as well. Let me know if you'd like me to do that for you too. 